### PR TITLE
Fix issue with arrow potentially not loading

### DIFF
--- a/src/M101SN.vue
+++ b/src/M101SN.vue
@@ -694,7 +694,7 @@ import { applyImageSetLayerSetting } from "@wwtelescope/engine-helpers";
 
 import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
 
-import { drawSkyOverlays, initializeConstellationNames, makeAltAzGridText, drawSpreadSheetLayer, layerManagerDraw } from "./wwt-hacks";
+import { drawSkyOverlays, getScreenPosForCoordinates, initializeConstellationNames, makeAltAzGridText, drawSpreadSheetLayer, layerManagerDraw } from "./wwt-hacks";
 
 interface MoveOptions {
   instant?: boolean;
@@ -715,6 +715,7 @@ import {
 
 const D2R = Math.PI / 180;
 const R2D = 180 / Math.PI;
+const D2H = 1 / 15;
 
 const SECONDS_PER_DAY = 60 * 60 * 24;
 const MILLISECONDS_PER_DAY = 1000 * SECONDS_PER_DAY;
@@ -859,6 +860,7 @@ export default defineComponent({
       m101RADeg: 3.681181581357794 * R2D + 0.2/60,
       m101DecDeg: 0.9480289529731357 * R2D - 1/60,
       arrowAngleDeg: -60,
+      arrowCreated: false,
 
       showSpeadSheetLater: false,
 
@@ -1043,20 +1045,19 @@ export default defineComponent({
       setTimeout(() => {
         this.centerView();
         this.positionSet = true;
-      }, 100);
 
-      this.gotoRADecZoom({
-        raRad: D2R * this.initialPosition.ra,
-        decRad: D2R * this.initialPosition.dec,
-        zoomDeg: 2,
-        instant: true
-      });
+        const createArrowFunction = () => {
+          try {
+            this.createArrow();
+            if (this.showArrow) {
+              this.displayArrow();
+            }
+          } catch (err) {
+            setTimeout(createArrowFunction, 100);
+          }
+        };
+        setTimeout(createArrowFunction, 100);
 
-      setTimeout(() => {
-        this.createArrow();
-        if (this.showArrow) {
-          this.displayArrow();
-        }
         this.gotoRADecZoom({
           raRad: this.wwtRARad,
           decRad: this.wwtDecRad,
@@ -1223,7 +1224,7 @@ export default defineComponent({
 
     createArrow() {
 
-      const m101XY = this.findScreenPointForRADec({ra: this.m101RADeg, dec: this.m101DecDeg});
+      const m101XY = getScreenPosForCoordinates(this.wwtControl, this.m101RADeg * D2H, this.m101DecDeg);
       const m101Point: Point = [m101XY.x, m101XY.y];
     
       // Create the outer (purple) arrow
@@ -1252,7 +1253,7 @@ export default defineComponent({
       outerArrowCoordinates.push([headBackRA, bottomDec]);
 
       for (const coords of outerArrowCoordinates) {
-        const point = this.findScreenPointForRADec({ra: coords[0], dec: coords[1]});
+        const point = getScreenPosForCoordinates(this.wwtControl, coords[0] * D2H, coords[1]);
         const rotatedPoint = this.rotatePoint([point.x, point.y], m101Point, this.arrowAngleDeg);
         const rotatedCoords = this.findRADecForScreenPoint({x: rotatedPoint[0], y: rotatedPoint[1]});
         this.outerArrow.addPoint(rotatedCoords.ra, rotatedCoords.dec);
@@ -1285,7 +1286,7 @@ export default defineComponent({
       innerArrowCoordinates.push([innerHeadBackRA, innerBottomDec]);
 
       for (const coords of innerArrowCoordinates) {
-        const point = this.findScreenPointForRADec({ra: coords[0], dec: coords[1]});
+        const point = getScreenPosForCoordinates(this.wwtControl, coords[0] * D2H, coords[1]);
         const rotatedPoint = this.rotatePoint([point.x, point.y], m101Point, this.arrowAngleDeg);
         const rotatedCoords = this.findRADecForScreenPoint({x: rotatedPoint[0], y: rotatedPoint[1]});
         this.innerArrow.addPoint(rotatedCoords.ra, rotatedCoords.dec);
@@ -1295,10 +1296,12 @@ export default defineComponent({
       this.innerArrow.set_lineColor(innerColor);
       this.innerArrow.set_fillColor(innerColor);
       this.innerArrow.set_fill(true);
+
+      this.arrowCreated = true;
     },
 
     displayArrow() {
-      if (this.outerArrow == null || this.innerArrow == null) {
+      if (!this.arrowCreated) {
         this.createArrow();
       }
       if (this.outerArrow) {

--- a/src/M101SN.vue
+++ b/src/M101SN.vue
@@ -1057,13 +1057,6 @@ export default defineComponent({
           }
         };
         setTimeout(createArrowFunction, 100);
-
-        this.gotoRADecZoom({
-          raRad: this.wwtRARad,
-          decRad: this.wwtDecRad,
-          zoomDeg: this.initialPosition.zoom,
-          instant: true
-        });
       }, 100);
 
     });


### PR DESCRIPTION
This PR should resolve #7. The basic approach here is to use the same "fractional pixels" idea that we used in the solar eclipse story. This allows us to draw the arrow without needing to secretly zoom in first. Also, rather than setting a timeout and hoping that WWT is ready, we now create the arrow via a timeout function that will repeat as many times as necessary - basically, it will either draw the arrow, or re-queue itself to run in 100ms if we hit an error.