### PR TITLE
Use NASA Grantee logo

### DIFF
--- a/src/Credits.vue
+++ b/src/Credits.vue
@@ -14,7 +14,7 @@
         ><img alt="SciAct Logo" src="https://cosmicds.github.io/cds-website/logos/logo_sciact.png"
       /></a>
       <a href="https://nasa.gov/" target="_blank" class="pl-1"
-        ><img alt="SciAct Logo" src="https://cosmicds.github.io/cds-website/logos/NASA_Grantee_color_no_outline.png"
+        ><img alt="NASA Grantee Logo" src="https://cosmicds.github.io/cds-website/logos/NASA_Grantee_color_no_outline.png"
       /></a>
     </div>
   </div>

--- a/src/Credits.vue
+++ b/src/Credits.vue
@@ -14,7 +14,7 @@
         ><img alt="SciAct Logo" src="https://cosmicds.github.io/cds-website/logos/logo_sciact.png"
       /></a>
       <a href="https://nasa.gov/" target="_blank" class="pl-1"
-        ><img alt="SciAct Logo" src="https://cosmicds.github.io/cds-website/logos/NASA_Partner_color_300_no_outline.png"
+        ><img alt="SciAct Logo" src="https://cosmicds.github.io/cds-website/logos/NASA_Grantee_color_no_outline.png"
       /></a>
     </div>
   </div>

--- a/src/M101SN.vue
+++ b/src/M101SN.vue
@@ -980,6 +980,8 @@ export default defineComponent({
       return this.layersLoaded && this.positionSet;
     },
     smallSize(): boolean {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       return this.$vuetify.display.smAndDown;
     },
     mobile(): boolean {


### PR DESCRIPTION
As the title says, this updates the story to use the NASA Grantee logo rather than the NASA Partner one. This time the change is in a local component. This also fixes some preexisting bad alt text for the NASA logo.

This also ignores a typing issue where, at least for me, the type checker wasn't picking up the component's `$vuetify` from the Vuetify plugin. It's only a typing issue - I've verified that `this.$vuetify` exists at runtime. Normally I'd want to hunt down why this is happening, but we don't use this type of setup anymore (as we've moved to the Composition API), and this story is finished, so it's really not the worth the time.